### PR TITLE
Remove os links para download das APIs da Fase 1 do repositório da fase 2.

### DIFF
--- a/documentation/source/includes/_open_banking.md.erb
+++ b/documentation/source/includes/_open_banking.md.erb
@@ -1,3 +1,2 @@
 <%= partial "./includes/partials_open_banking/open_banking_apis" %>
 <%= partial "./includes/partials_open_banking/disclosure_fees_interest_rates" %>
-<%= partial "./includes/partials_open_banking/swagger" %>

--- a/documentation/source/includes/partials_open_banking/_swagger.md.erb
+++ b/documentation/source/includes/partials_open_banking/_swagger.md.erb
@@ -1,6 +1,0 @@
-# Especificação em OAS 3.0
-
-* <a href='swagger/swagger_common_apis.yaml'>Download da Especificação (OAS 3.0) | APIs Comuns </a>
-* <a href='swagger/swagger_channels_apis.yaml'>Download da Especificação (OAS 3.0) | API - Canais de Atendimento</a>
-* <a href='swagger/swagger_products_services_apis.yaml'>Download da Especificação (OAS 3.0) | API - Produtos e Serviços</a>
-* <a href='swagger/swagger_admin_apis.yaml'>Download da Especificação (OAS 3.0) | API - Admin</a>


### PR DESCRIPTION
# Descrição

Os links para download das APIs da Fase 1 ainda estavam presentes nesse repositório.

# Solução

Remoção dos links para facilitar na revisão de código por parte dos GTs.
