### PR TITLE
Adiciona a seção de parâmetros dentro de componentes nas especificações Open API

### DIFF
--- a/documentation/source/swagger/parts/_accounts_apis_part.yml
+++ b/documentation/source/swagger/parts/_accounts_apis_part.yml
@@ -32,16 +32,16 @@ paths:
       description: Método para obter os dados de identificação da conta de depósito à vista, poupança ou pagamento pré-paga identificada por accountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsAccountId
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/AccountId.yaml
-        - $ref: ./parameters/AccountsCompeCode.yaml
-        - $ref: ./parameters/AccountsBranchCode.yaml
-        - $ref: ./parameters/AccountsNumber.yaml
-        - $ref: ./parameters/AccountsCheckDigit.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/accountsCompeCode'
+        - $ref: '#/components/parameters/accountsBranchCode'
+        - $ref: '#/components/parameters/accountsNumber'
+        - $ref: '#/components/parameters/accountsCheckDigit'
       responses:
         "200":
           description: Dados de identificação da conta identificada por accountId obtidos com sucesso.
@@ -74,16 +74,16 @@ paths:
       description: Método para obter os saldos da conta de depósito à vista, poupança ou pagamento pré-paga identificada por accountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsAccountIdBalances
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/AccountId.yaml
-        - $ref: ./parameters/AccountsCompeCode.yaml
-        - $ref: ./parameters/AccountsBranchCode.yaml
-        - $ref: ./parameters/AccountsNumber.yaml
-        - $ref: ./parameters/AccountsCheckDigit.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/accountsCompeCode'
+        - $ref: '#/components/parameters/accountsBranchCode'
+        - $ref: '#/components/parameters/accountsNumber'
+        - $ref: '#/components/parameters/accountsCheckDigit'
       responses:
         "200":
           description: Dados relativos aos saldos da conta identificada por accountId obtidos com sucesso.
@@ -116,21 +116,21 @@ paths:
       description: Método para obter a lista de transações da conta de depósito à vista, poupança ou pagamento pré-paga identificada por accountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsAccountIdTransactions
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/AccountId.yaml
-        - $ref: ./parameters/AccountsCompeCode.yaml
-        - $ref: ./parameters/AccountsBranchCode.yaml
-        - $ref: ./parameters/AccountsNumber.yaml
-        - $ref: ./parameters/AccountsCheckDigit.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/FromBookingDate.yaml
-        - $ref: ./parameters/ToBookingDate.yaml
-        - $ref: ./parameters/CreditCardDebitIndicator.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/accountsCompeCode'
+        - $ref: '#/components/parameters/accountsBranchCode'
+        - $ref: '#/components/parameters/accountsNumber'
+        - $ref: '#/components/parameters/accountsCheckDigit'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/fromBookingDate'
+        - $ref: '#/components/parameters/toBookingDate'
+        - $ref: '#/components/parameters/creditDebitIndicator'
       responses:
         "200":
           description: Dados da lista de transações da conta identificada por accountId obtidos com sucesso.
@@ -163,16 +163,16 @@ paths:
       description: Método para obter os limites da conta de depósito à vista, poupança ou pagamento pré-paga identificada por accountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsAccountIdOverdraftLimits
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/AccountId.yaml
-        - $ref: ./parameters/AccountsCompeCode.yaml
-        - $ref: ./parameters/AccountsBranchCode.yaml
-        - $ref: ./parameters/AccountsNumber.yaml
-        - $ref: ./parameters/AccountsCheckDigit.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/accountsCompeCode'
+        - $ref: '#/components/parameters/accountsBranchCode'
+        - $ref: '#/components/parameters/accountsNumber'
+        - $ref: '#/components/parameters/accountsCheckDigit'
       responses:
         "200":
           description: Dados de limites da conta identificada por accountId obtidos com sucesso.
@@ -206,3 +206,35 @@ components:
       $ref: ./schemas/accounts_apis/ResponseAccountOverdraftLimits.yaml
     ResponseAccountTransactions:
       $ref: ./schemas/accounts_apis/ResponseAccountTransactions.yaml
+  parameters:
+    accountId:
+      $ref: ./parameters/AccountId.yaml
+    accountsBranchCode:
+      $ref: ./parameters/AccountsBranchCode.yaml
+    accountsCheckDigit:
+      $ref: ./parameters/AccountsCheckDigit.yaml
+    accountsCompeCode:
+      $ref: ./parameters/AccountsCompeCode.yaml
+    accountsNumber:
+      $ref: ./parameters/AccountsNumber.yaml
+    Authorization:
+      $ref: ./parameters/Authorization.yaml
+    creditDebitIndicator:
+      $ref: ./parameters/CreditCardDebitIndicator.yaml
+    fromBookingDate:
+      $ref: ./parameters/FromBookingDate.yaml
+    page:
+      $ref: ./parameters/Page.yaml
+    pageSize:
+      $ref: ./parameters/PageSize.yaml
+    toBookingDate:
+      $ref: ./parameters/ToBookingDate.yaml
+    xCustomerUserAgent:
+      $ref: ./parameters/XCustomerUserAgent.yaml
+    xFapiAuthDate:
+      $ref: ./parameters/XFapiAuthDate.yaml
+    xFapiCustomerIpAddress:
+      $ref: ./parameters/XFapiCustomerIpAddress.yaml
+    xFapiInteractionId:
+      $ref: ./parameters/XFapiInteractionId.yaml
+    

--- a/documentation/source/swagger/parts/_credit_cards_apis_part.yml
+++ b/documentation/source/swagger/parts/_credit_cards_apis_part.yml
@@ -30,12 +30,12 @@ paths:
       description: Método para obter os dados de identificação da conta de pagamento pós-paga identificada por creditCardAccountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsCreditCardAccountId
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/CreditCardAccountId.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/creditCardAccountId'
       responses:
         '200':
           description: Dados de identificação da conta identificada por creditCardAccountId obtidos com sucesso.
@@ -68,16 +68,16 @@ paths:
       description: Método para obter a lista de faturas da conta de pagamento pós-paga identificada por creditCardAccountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsCreditCardAccountIdBills
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/CreditCardAccountId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/FromDueDate.yaml
-        - $ref: ./parameters/ToDueDate.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/creditCardAccountId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/fromDueDate'
+        - $ref: '#/components/parameters/toDueDate'
       responses:
         '200':
           description: Dados referentes à lista de faturas da conta identificada por creditCardAccountId obtidos com sucesso.
@@ -112,12 +112,12 @@ paths:
         Método para obter os limites da conta de pagamento pós-paga identificada por creditCardAccountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsCreditCardAccountIdLimits
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/CreditCardAccountId.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/creditCardAccountId'
       responses:
         '200':
           description: Dados dos limites da conta identificada por creditCardAccountId obtidos com sucesso.
@@ -150,18 +150,18 @@ paths:
       description: Método para obter a lista de transações da conta de pagamento pós-paga identificada por creditCardAccountId mantida pelo cliente na instituição transmissora.
       operationId: getAccountsCreditCardAccountIdTransactions
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/CreditCardAccountId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/FromTransactionDate.yaml
-        - $ref: ./parameters/ToTransactionDate.yaml
-        - $ref: ./parameters/CreditCardTransactionType.yaml
-        - $ref: ./parameters/CreditCardPayeeMCC.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/creditCardAccountId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/fromTransactionDate'
+        - $ref: '#/components/parameters/toTransactionDate'
+        - $ref: '#/components/parameters/creditCardTransactionType'
+        - $ref: '#/components/parameters/creditCardPayeeMCC'
       responses:
         '200':
           description: Dados das lista de transações da conta identificada por creditCardAccountId obtidos com sucesso.
@@ -195,3 +195,32 @@ components:
       $ref: ./schemas/credit_cards_apis/ResponseCreditCardAccountsLimits.yaml
     ResponseCreditCardAccountsTransactions:
       $ref: ./schemas/credit_cards_apis/ResponseCreditCardAccountsTransactions.yaml
+  parameters:
+    Authorization:
+      $ref: ./parameters/Authorization.yaml
+    creditCardAccountId:
+      $ref: ./parameters/CreditCardAccountId.yaml
+    creditCardPayeeMCC:
+      $ref: ./parameters/CreditCardPayeeMCC.yaml
+    creditCardTransactionType:
+      $ref: ./parameters/CreditCardTransactionType.yaml
+    fromDueDate:
+      $ref: ./parameters/FromDueDate.yaml
+    fromTransactionDate:
+      $ref: ./parameters/FromTransactionDate.yaml
+    page:
+      $ref: ./parameters/Page.yaml
+    pageSize:
+      $ref: ./parameters/PageSize.yaml
+    toDueDate:
+      $ref: ./parameters/ToDueDate.yaml
+    toTransactionDate:
+      $ref: ./parameters/ToTransactionDate.yaml
+    xCustomerUserAgent:
+      $ref: ./parameters/XCustomerUserAgent.yaml
+    xFapiAuthDate:
+      $ref: ./parameters/XFapiAuthDate.yaml
+    xFapiCustomerIpAddress:
+      $ref: ./parameters/XFapiCustomerIpAddress.yaml
+    xFapiInteractionId:
+      $ref: ./parameters/XFapiInteractionId.yaml

--- a/documentation/source/swagger/parts/_customers_apis_part.yml
+++ b/documentation/source/swagger/parts/_customers_apis_part.yml
@@ -29,13 +29,13 @@ paths:
       description: Método para obter os registros de identificação da pessoa natural mantidos na instituição transmissora.
       operationId: getCustomersPersonalIdentifications
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados sobre identificação pessoa física.
@@ -68,13 +68,13 @@ paths:
       description: Método para obter os registros de qualificação da pessoa natural mantidos na instituição transmissora.
       operationId: getPersonalCustomersQualifications
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados sobre qualificação da pessoa física
@@ -107,13 +107,13 @@ paths:
       description: Método para obter registros de relacionamentos com a instituição financeira e de representantes da pessoa natural mantidos na instituição transmissora.
       operationId: getCustomersPersonalRelationships
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados sobre relacionamento da pessoa física
@@ -147,13 +147,13 @@ paths:
 
       operationId: getCustomersBusinessIdentifications
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados sobre identificação pessoa jurídica
@@ -186,13 +186,13 @@ paths:
       description: Método para obter os registros de qualificação da pessoa jurídica mantidos na instituição transmissora.
       operationId: getCustomersBusinessQualifications
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados sobre qualificação pessoa jurídica
@@ -225,13 +225,13 @@ paths:
       description: Método para obter registros de relacionamentos com a instituição financeira e de representantes da pessoa jurídica mantidos na instituição transmissora.
       operationId: getCustomersBusinessRelationships
       parameters:
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados sobre relacionamento pessoa jurídica
@@ -270,3 +270,19 @@ components:
       $ref: ./schemas/customers_apis/ResponsePersonalCustomersIdentification.yaml
     ResponsePersonalCustomersQualification:
       $ref: ./schemas/customers_apis/ResponsePersonalCustomersQualification.yaml
+  parameters:
+    Authorization:
+      $ref: ./parameters/Authorization.yaml
+    page:
+      $ref: ./parameters/Page.yaml
+    pageSize:
+      $ref: ./parameters/PageSize.yaml
+    xCustomerUserAgent:
+      $ref: ./parameters/XCustomerUserAgent.yaml
+    xFapiAuthDate:
+      $ref: ./parameters/XFapiAuthDate.yaml
+    xFapiCustomerIpAddress:
+      $ref: ./parameters/XFapiCustomerIpAddress.yaml
+    xFapiInteractionId:
+      $ref: ./parameters/XFapiInteractionId.yaml
+

--- a/documentation/source/swagger/parts/_financings_apis_part.yml
+++ b/documentation/source/swagger/parts/_financings_apis_part.yml
@@ -29,12 +29,12 @@ paths:
       description: Método para obter os dados do contrato de financiamento identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractId
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do contrato de financiamento identificado por contractId
@@ -67,14 +67,14 @@ paths:
       description: Método para obter a lista de garantias vinculadas ao contrato de financiamento identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdWarranties
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Lista de garantias vinculadas ao contrato de financiamento identificado por contractId
@@ -107,14 +107,14 @@ paths:
       description: Método para obter os dados do cronograma de parcelas do contrato de financiamento identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdInstalments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do cronograma de parcelas do contrato de financiamento identificado por contractId
@@ -147,14 +147,14 @@ paths:
       description: Método para obter os dados de pagamentos do contrato de financiamento identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdPayments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados de pagamentos do contrato de financiamento identificado por contractId
@@ -188,3 +188,21 @@ components:
       $ref: ./schemas/financings_apis/ResponseFinancingsPayments.yaml
     ResponseFinancingsWarranties:
       $ref: ./schemas/financings_apis/ResponseFinancingsWarranties.yaml
+  parameters:
+    Authorization:
+      $ref: ./parameters/Authorization.yaml
+    contractId:
+      $ref: ./parameters/ContractId.yaml
+    page:
+      $ref: ./parameters/Page.yaml
+    pageSize:
+      $ref: ./parameters/PageSize.yaml
+    xCustomerUserAgent:
+      $ref: ./parameters/XCustomerUserAgent.yaml
+    xFapiAuthDate:
+      $ref: ./parameters/XFapiAuthDate.yaml
+    xFapiCustomerIpAddress:
+      $ref: ./parameters/XFapiCustomerIpAddress.yaml
+    xFapiInteractionId:
+      $ref: ./parameters/XFapiInteractionId.yaml
+

--- a/documentation/source/swagger/parts/_invoice_financings_apis_part.yml
+++ b/documentation/source/swagger/parts/_invoice_financings_apis_part.yml
@@ -29,12 +29,12 @@ paths:
       description: Método para obter os dados do contrato de antecipação de recebíveis identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractId
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do contrato de antecipação de recebíveis identificado por contractId
@@ -67,14 +67,14 @@ paths:
       description: Método para obter a lista de garantias vinculadas ao contrato de antecipação de recebíveis identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdWarranties
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Lista de garantias vinculadas ao contrato de antecipação de recebíveis identificado por contractId
@@ -107,14 +107,14 @@ paths:
       description: Método para obter os dados do cronograma de parcelas do contrato de antecipação de recebíveis identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdInstalments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do cronograma de parcelas do contrato de antecipação de recebíveis identificado por contractId
@@ -147,14 +147,14 @@ paths:
       description: Método para obter os dados de pagamentos do contrato de antecipação de recebíveis identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdPayments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados de pagamentos do contrato de antecipação de recebíveis identificado por contractId
@@ -188,4 +188,21 @@ components:
       $ref: ./schemas/invoice_financings_apis/ResponseInvoiceFinancingsPayments.yaml
     ResponseInvoiceFinancingsWarranties:
       $ref: ./schemas/invoice_financings_apis/ResponseInvoiceFinancingsWarranties.yaml
+  parameters:
+    Authorization:
+      $ref: ./parameters/Authorization.yaml
+    contractId:
+      $ref: ./parameters/ContractId.yaml
+    page:
+      $ref: ./parameters/Page.yaml
+    pageSize:
+      $ref: ./parameters/PageSize.yaml
+    xCustomerUserAgent:
+      $ref: ./parameters/XCustomerUserAgent.yaml
+    xFapiAuthDate:
+      $ref: ./parameters/XFapiAuthDate.yaml
+    xFapiCustomerIpAddress:
+      $ref: ./parameters/XFapiCustomerIpAddress.yaml
+    xFapiInteractionId:
+      $ref: ./parameters/XFapiInteractionId.yaml
 

--- a/documentation/source/swagger/parts/_loans_apis_part.yml
+++ b/documentation/source/swagger/parts/_loans_apis_part.yml
@@ -29,12 +29,12 @@ paths:
       description: Método para obter os dados do contrato de empréstimo identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractId
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do contrato de empréstimo identificado por contractId
@@ -67,14 +67,14 @@ paths:
       description: Método para obter a lista de garantias vinculadas ao contrato de empréstimo identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdWarranties
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Lista de garantias vinculadas ao contrato de empréstimo identificado por contractId
@@ -107,14 +107,14 @@ paths:
       description: Método para obter os dados do cronograma de parcelas do contrato de empréstimo identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdInstalments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do cronograma de parcelas do contrato de empréstimo identificado por contractId
@@ -147,14 +147,14 @@ paths:
       description: Método para obter os dados de pagamentos do contrato de empréstimo identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdPayments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados de pagamentos do contrato de empréstimo identificado por contractId
@@ -188,3 +188,20 @@ components:
       $ref: ./schemas/loans_apis/ResponseLoansPayments.yaml
     ResponseLoansWarranties:
       $ref: ./schemas/loans_apis/ResponseLoansWarranties.yaml
+  parameters:
+    Authorization:
+      $ref: ./parameters/Authorization.yaml
+    contractId:
+      $ref: ./parameters/ContractId.yaml
+    page:
+      $ref: ./parameters/Page.yaml
+    pageSize:
+      $ref: ./parameters/PageSize.yaml
+    xCustomerUserAgent:
+      $ref: ./parameters/XCustomerUserAgent.yaml
+    xFapiAuthDate:
+      $ref: ./parameters/XFapiAuthDate.yaml
+    xFapiCustomerIpAddress:
+      $ref: ./parameters/XFapiCustomerIpAddress.yaml
+    xFapiInteractionId:
+      $ref: ./parameters/XFapiInteractionId.yaml

--- a/documentation/source/swagger/parts/_unarranged_accounts_overdraft_apis_part.yml
+++ b/documentation/source/swagger/parts/_unarranged_accounts_overdraft_apis_part.yml
@@ -29,12 +29,12 @@ paths:
       description: Método para obter os dados do contrato de adiantamento a depositantes identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractId
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do contrato de adiantamento a depositantes identificado por contractId
@@ -67,14 +67,14 @@ paths:
       description: Método para obter a lista de garantias vinculadas ao contrato de adiantamento a depositantes identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdWarranties
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Lista de garantias vinculadas ao contrato de adiantamento a depositantes identificado por contractId
@@ -107,14 +107,14 @@ paths:
       description: Método para obter os dados do cronograma de parcelas do contrato de adiantamento a depositantes identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdInstalments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados do cronograma de parcelas do contrato de adiantamento a depositantes identificado por contractId
@@ -147,14 +147,14 @@ paths:
       description: Método para obter os dados de pagamentos do contrato de adiantamento a depositantes identificado por contractId mantido pelo cliente na instituição transmissora
       operationId: getContractsContractIdPayments
       parameters:
-        - $ref: ./parameters/ContractId.yaml
-        - $ref: ./parameters/Page.yaml
-        - $ref: ./parameters/PageSize.yaml
-        - $ref: ./parameters/Authorization.yaml
-        - $ref: ./parameters/XFapiAuthDate.yaml
-        - $ref: ./parameters/XFapiCustomerIpAddress.yaml
-        - $ref: ./parameters/XFapiInteractionId.yaml
-        - $ref: ./parameters/XCustomerUserAgent.yaml
+        - $ref: '#/components/parameters/contractId'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
       responses:
         '200':
           description: Dados de pagamentos do contrato de adiantamento a depositantes identificado por contractId
@@ -188,3 +188,20 @@ components:
       $ref: ./schemas/unarranged_account_overdraft_apis/ResponseUnarrangedAccountOverdraftPayments.yaml
     ResponseUnarrangedAccountOverdraftWarranties:
       $ref: ./schemas/unarranged_account_overdraft_apis/ResponseUnarrangedAccountOverdraftWarranties.yaml
+  parameters:
+    Authorization:
+      $ref: ./parameters/Authorization.yaml
+    contractId:
+      $ref: ./parameters/ContractId.yaml
+    page:
+      $ref: ./parameters/Page.yaml
+    pageSize:
+      $ref: ./parameters/PageSize.yaml
+    xCustomerUserAgent:
+      $ref: ./parameters/XCustomerUserAgent.yaml
+    xFapiAuthDate:
+      $ref: ./parameters/XFapiAuthDate.yaml
+    xFapiCustomerIpAddress:
+      $ref: ./parameters/XFapiCustomerIpAddress.yaml
+    xFapiInteractionId:
+      $ref: ./parameters/XFapiInteractionId.yaml


### PR DESCRIPTION
# Descrição

A seção de parâmetros não havia sido adicionada na primeira versão da entrega das APIs da fase 2, isso acaba atrapalhando a visualização das definições em editores de texto comum.

# Solução

Adicionada a seção de parâmetros logo abaixo de components e realizado a referência nos endpoints para os memos.