### PR TITLE
Corrige alguns schemas para que as referencias do bundle gerado fique correta.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,14 @@ jobs:
 
       - run: sed -i '1s/^\(\xef\xbb\xbf\)\?/\xef\xbb\xbf/' source/swagger/swagger_*
 
+      - run: swagger-cli validate source/swagger/swagger_customers_apis.yaml
+      - run: swagger-cli validate source/swagger/swagger_credit_cards_apis.yaml
+      - run: swagger-cli validate source/swagger/swagger_accounts_apis.yaml
+      - run: swagger-cli validate source/swagger/swagger_loans_apis.yaml
+      - run: swagger-cli validate source/swagger/swagger_financings_apis.yaml
+      - run: swagger-cli validate source/swagger/swagger_unarranged_accounts_overdraft_apis.yaml
+      - run: swagger-cli validate source/swagger/swagger_invoice_financings_apis.yaml
+
       - run: widdershins source/swagger/swagger_open_banking_apis.yml -o source/includes/partials_open_banking/_open_banking_apis.md.erb --user_templates source/templates/openapi3/ --language_tabs "javascript:JavaScript:request" "python:Python:request" "java:Java::request" --omitHeader --summary --httpsnippet
 
       - uses: actions/cache@v1

--- a/documentation/build.sh
+++ b/documentation/build.sh
@@ -11,6 +11,14 @@ swagger-cli bundle source/swagger/parts/_open_banking_apis_part.yml --outfile so
 
 sed -i '1s/^\(\xef\xbb\xbf\)\?/\xef\xbb\xbf/' source/swagger/swagger_*
 
+swagger-cli validate source/swagger/swagger_customers_apis.yaml
+swagger-cli validate source/swagger/swagger_credit_cards_apis.yaml
+swagger-cli validate source/swagger/swagger_accounts_apis.yaml
+swagger-cli validate source/swagger/swagger_loans_apis.yaml
+swagger-cli validate source/swagger/swagger_financings_apis.yaml
+swagger-cli validate source/swagger/swagger_unarranged_accounts_overdraft_apis.yaml
+swagger-cli validate source/swagger/swagger_invoice_financings_apis.yaml
+
 widdershins source/swagger/swagger_open_banking_apis.yml -o source/includes/partials_open_banking/_open_banking_apis.md.erb --user_templates source/templates/openapi3/ --language_tabs "javascript:JavaScript:request" "python:Python:request" "java:Java::request" --omitHeader --summary --httpsnippet
 
 spectral lint source/swagger/*_apis.yaml

--- a/documentation/source/swagger/parts/_open_banking_apis_part.yml
+++ b/documentation/source/swagger/parts/_open_banking_apis_part.yml
@@ -2487,8 +2487,6 @@ components:
       $ref: ./schemas/credit_cards_apis/CreditCardsAccountsPaymentMethod.yaml
     CreditCardTransactionAccount:
       $ref: ./schemas/credit_cards_apis/CreditCardTransactionAccount.yaml
-    Currency:
-      $ref: ./schemas/Currency.yaml
     CustomerContacts:
       $ref: ./schemas/customers_apis/CustomerContacts.yaml
     CustomerEmail:

--- a/documentation/source/swagger/parts/schemas/Currency.yaml
+++ b/documentation/source/swagger/parts/schemas/Currency.yaml
@@ -1,6 +1,0 @@
-type: string
-pattern: ^(\w{3}){1}$
-maxLength: 3
-format: CurrencyString
-description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217
-example: "BRL"

--- a/documentation/source/swagger/parts/schemas/accounts_apis/Balances.yaml
+++ b/documentation/source/swagger/parts/schemas/accounts_apis/Balances.yaml
@@ -60,7 +60,12 @@ properties:
     example: '2020-07-21T08:30:00Z'
     description: Data e hora da consulta, conforme especificação RFC-3339, formato UTC.
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217
+    example: "BRL"
   statementAccount:
     type: array
     items:

--- a/documentation/source/swagger/parts/schemas/accounts_apis/Transactions.yaml
+++ b/documentation/source/swagger/parts/schemas/accounts_apis/Transactions.yaml
@@ -61,7 +61,12 @@ properties:
     example: '2020-07-21T08:30:00Z'
     description: Data e hora da consulta, conforme especificação RFC-3339, formato UTC.
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217
+    example: "BRL"
   statementAccount:
     type: array
     items:

--- a/documentation/source/swagger/parts/schemas/customers_apis/BusinessFinancialRelationCustomers.yaml
+++ b/documentation/source/swagger/parts/schemas/customers_apis/BusinessFinancialRelationCustomers.yaml
@@ -1,9 +1,7 @@
 type: object
 description: Conjunto de informações cadastrais do Cliente pessoa jurídica.
-items:
-  type: object
-  required:
-    - financialRelation
-  properties:
-    financialRelation:
-      $ref: ./FinancialRelation.yaml
+required:
+  - financialRelation
+properties:
+  financialRelation:
+    $ref: ./FinancialRelation.yaml

--- a/documentation/source/swagger/parts/schemas/financings_apis/FinancingsBalloonPayment.yaml
+++ b/documentation/source/swagger/parts/schemas/financings_apis/FinancingsBalloonPayment.yaml
@@ -5,7 +5,12 @@ required:
   - instalments
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217
+    example: "BRL"
   instalments:
     type: array
     description: Lista que traz as datas de vencimento e valor das parcelas não regulares  do contrato da modalidade de crédito consultada

--- a/documentation/source/swagger/parts/schemas/financings_apis/FinancingsNonRegulatedCharge.yaml
+++ b/documentation/source/swagger/parts/schemas/financings_apis/FinancingsNonRegulatedCharge.yaml
@@ -3,4 +3,8 @@ required:
   - currency
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217

--- a/documentation/source/swagger/parts/schemas/invoice_financings_apis/InvoiceFinancingsBalloonPayment.yaml
+++ b/documentation/source/swagger/parts/schemas/invoice_financings_apis/InvoiceFinancingsBalloonPayment.yaml
@@ -5,7 +5,11 @@ required:
   - instalments
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217
   instalments:
     type: array
     description: Lista que traz as datas de vencimento e valor das parcelas não regulares  do contrato da modalidade de crédito consultada

--- a/documentation/source/swagger/parts/schemas/invoice_financings_apis/InvoiceFinancingsNonRegulatedCharge.yaml
+++ b/documentation/source/swagger/parts/schemas/invoice_financings_apis/InvoiceFinancingsNonRegulatedCharge.yaml
@@ -3,4 +3,8 @@ required:
   - currency
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217

--- a/documentation/source/swagger/parts/schemas/loans_apis/LoansBalloonPayment.yaml
+++ b/documentation/source/swagger/parts/schemas/loans_apis/LoansBalloonPayment.yaml
@@ -5,7 +5,11 @@ required:
   - instalments
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217
   instalments:
     type: array
     description: Lista que traz as datas de vencimento e valor das parcelas não regulares  do contrato da modalidade de crédito consultada

--- a/documentation/source/swagger/parts/schemas/loans_apis/LoansNonRegulatedCharge.yaml
+++ b/documentation/source/swagger/parts/schemas/loans_apis/LoansNonRegulatedCharge.yaml
@@ -3,4 +3,8 @@ required:
   - currency
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217

--- a/documentation/source/swagger/parts/schemas/unarranged_account_overdraft_apis/UnarrangedAccountOverdraftBalloonPayment.yaml
+++ b/documentation/source/swagger/parts/schemas/unarranged_account_overdraft_apis/UnarrangedAccountOverdraftBalloonPayment.yaml
@@ -5,7 +5,11 @@ required:
   - instalments
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217
   instalments:
     type: array
     description: Lista que traz as datas de vencimento e valor das parcelas não regulares  do contrato da modalidade de crédito consultada

--- a/documentation/source/swagger/parts/schemas/unarranged_account_overdraft_apis/UnarrangedAccountOverdraftNonRegulatedCharge.yaml
+++ b/documentation/source/swagger/parts/schemas/unarranged_account_overdraft_apis/UnarrangedAccountOverdraftNonRegulatedCharge.yaml
@@ -3,4 +3,8 @@ required:
   - currency
 properties:
   currency:
-    $ref: ../Currency.yaml
+    type: string
+    pattern: ^(\w{3}){1}$
+    maxLength: 3
+    format: CurrencyString
+    description: Moeda referente ao valor mínimo da Tarifa, segundo modelo ISO-4217


### PR DESCRIPTION
# Descrição

Algumas especificações não estavam corretas fazendo com que as referências dos swaggers gerados como bundle ficassem incorretas.

# Solução

Correção em especificações e adição de passos de validação dos schemas no pipeline.